### PR TITLE
add: read-from-stdin mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@
 ayashii -- AYASHII NIHONGO CLI: Convert from normal Japanese text to AYASHII NIHONGO.
 
 USAGE
-    ayashii TEXT        # from arguments
-    echo TEXT | ayashii # from stdin
-    ayashii --help      # Show this help.
+    ayashii TEXT        # read from arguments
+    echo TEXT | ayashii # read from pipe
+    ayashii -s <<< TEXT # read from stdin
+    ayashii --help      # show this help
 
 EXAMPLE
     $ ayashii これは正しい日本語です！

--- a/ayashii
+++ b/ayashii
@@ -12,9 +12,10 @@ function _help() {
 ayashii -- AYASHII NIHONGO CLI: Convert from normal Japanese text to AYASHII NIHONGO.
 
 USAGE
-    ayashii TEXT        # from arguments
-    echo TEXT | ayashii # from stdin
-    ayashii --help      # Show this help.
+    ayashii TEXT        # read from arguments
+    echo TEXT | ayashii # read from pipe
+    ayashii -s <<< TEXT # read from stdin
+    ayashii --help      # show this help
 
 EXAMPLE
     $ ayashii これは正しい日本語です！
@@ -38,8 +39,7 @@ function _err() {
 }
 
 function _to_ayashii() {
-    text="${*}"
-    echo "$text" | sed '
+    sed '
     # source: https://github.com/Submarinonline/cjp.js/tree/master/dict
 
     # emoji.json
@@ -322,26 +322,33 @@ function _to_ayashii() {
 }
 
 function _main() {
-    if [ -p /dev/stdin ]; then
-        _to_ayashii "$(cat /dev/stdin)"
-        return "${?}"
-    fi
+    for arg in "${@}"; do
+        case "${arg}" in
+        -h | --help)
+            _help
+            return 0
+            ;;
+        -s | --stdin)
+            # From interpreter
+            _to_ayashii
+            return "${?}"
+        esac
+    done
 
-    if [ "${#}" -lt 1 ]; then
+    if [ -p /dev/stdin ]
+    then
+        # From pipe
+        _to_ayashii < /dev/stdin
+        return "${?}"
+    elif [ "${#}" -eq 0 ]; then
         _help
         _err "Must require arguments..."
         return 1
+    else
+        # From arg
+        _to_ayashii <<<"$@"
+        return "${?}"
     fi
-
-    for arg in "${@}"; do
-        if [ "${arg}" = '--help' ]; then
-            _help
-            return 0
-        fi
-    done
-
-    _to_ayashii "${*}"
-    return "${?}"
 }
 
 _main "$@"


### PR DESCRIPTION
匕マドキュ〆ソ卜や刂ダ亻レケ卜へゐ対応ゐだめ、`-s, --stdin`才プツ゚彐ソを追加レまレだ。
`echo-sd`ゐように`-s`がなければ强制的に引数ゐみて文字を受け取ゑようにレてもいいなと思いまレだが、现状は`echo TEXT|ayashii`ても大丈夫なようにレてあ刂まず。

```bash
$ ./ayashii こんにちは！
ごんにさは！
$ ./ayashii <<<こんにちは！
ayashii -- AYASHII NIHONGO CLI: Convert from normal Japanese text to AYASHII NIHONGO.

USAGE
    ayashii TEXT        # read from arguments
    echo TEXT | ayashii # read from pipe
    ayashii -s <<< TEXT # read from stdin
    ayashii --help      # show this help

EXAMPLE
    $ ayashii これは正しい日本語です！
    これは正レい日本语てず！
    $ echo これは正しい日本語です！ | ayashii
    これは正レい日本语てず！

REPO
    Repository:      https://github.com/sheepla/ayashii-cli
    Author:          sheepla (https://github.com/sheepla)
    Licence:         MIT

DICT
    This tool using this dictionaries. thanks!
    https://github.com/Submarinonline/cjp.js/tree/master/dict

[ ERR ] Must require arguments...
$ ./ayashii -s <<<こんにちは！
ごんにさは！
$ ./ayashii -s <<'A'
heredoc> ITを制するものは
heredoc> 受験を制す！
heredoc> A
ITを制ずゑもゐは
受験を制ず！
$ echo ごんにさは！ | ./ayashii
ごんにさは！
$ echo ごんにさは！ | ./ayashii -s
ごんにさは！
$ ./ayashii -s
うんこうんち
うんこうんち
うんこらんち
うんこらんち
ウンコランチ
ウソコうソ于
^C
$
```        